### PR TITLE
Automatically set theme based on syntax background theme

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -4,11 +4,6 @@ import View from './view.js';
 
 export default {
     config: {
-        lightTheme: {
-            type       : 'boolean',
-            default    : false,
-            description: 'Use light theme styles'
-        },
         minimapLine: {
             type       : 'boolean',
             default    : true,

--- a/lib/view.js
+++ b/lib/view.js
@@ -117,16 +117,13 @@ export default class View {
             invalidate: 'touch'
         });
 
-        let isLightTheme = atom.config.get('es-identifier-highlight.lightTheme');
-
         editor.decorateMarker(marker, {
             type: type,
             class: classNames(
                 'es-identifier-highlight',
                 classes,
                 {
-                    'line': type === 'line',
-                    'light-theme': isLightTheme
+                    'line': type === 'line'
                 }
             )
         });

--- a/styles/es-identifier-highlight.less
+++ b/styles/es-identifier-highlight.less
@@ -43,17 +43,17 @@
 // Minimap styles
 .minimap-highlights() when (lightness(@syntax-background-color) > 50%) {
   // Light theme
-  .es-identifier-highlight.light-theme {
+  .es-identifier-highlight {
     background-color: fade(#000, 80%);
     border:1px solid #333;
   }
 
-  .es-identifier-highlight.light-theme.line {
+  .es-identifier-highlight.line {
     background-color: fade(#f0adf0, 80%);;
     border:none;
   }
 
-  .es-identifier-highlight.light-theme.line.definition {
+  .es-identifier-highlight.line.definition {
     background-color: fade(#baa8ff, 80%);
     border:none;
   }

--- a/styles/es-identifier-highlight.less
+++ b/styles/es-identifier-highlight.less
@@ -2,6 +2,28 @@
 @import "syntax-variables";
 
 // Text editor styles
+.highlights() when (lightness(@syntax-background-color) > 50%) {
+  // Light theme
+  .es-identifier-highlight .region {
+    background-color: fade(#e4e4ff, 80%);
+  }
+
+  .es-identifier-highlight.definition .region {
+    background-color: fade(#ffe4ff, 80%);
+  }
+}
+
+.highlights() when (lightness(@syntax-background-color) <= 50%) {
+  // Default theme
+  .es-identifier-highlight .region {
+    background-color: fade(#344134, 80%);
+  }
+
+  .es-identifier-highlight.definition .region {
+    background-color: fade(#40332b, 80%);
+  }
+}
+
 :host, atom-text-editor, atom-text-editor::shadow {
   atom-text-editor .highlight.es-identifier-highlight .region {
     position: absolute;
@@ -14,45 +36,12 @@
       box-sizing: border-box;
       z-index:-2;
     }
-
-    // Default theme
-    .es-identifier-highlight .region {
-      background-color: fade(#344134, 80%);
-    }
-
-    .es-identifier-highlight.definition .region {
-      background-color: fade(#40332b, 80%);
-    }
-
-    // Light theme
-    .es-identifier-highlight.light-theme .region {
-      background-color: fade(#e4e4ff, 80%);
-    }
-
-    .es-identifier-highlight.light-theme.definition .region {
-      background-color: fade(#ffe4ff, 80%);
-    }
+    .highlights();
   }
 }
 
 // Minimap styles
-.minimap {
-  // Default theme
-  .es-identifier-highlight {
-    background-color: @text-color-highlight;
-    border:1px solid #ddd;
-  }
-
-  .es-identifier-highlight.line {
-    background-color: fade(#036b13, 80%);
-    border:none;
-  }
-
-  .es-identifier-highlight.line.definition {
-    background-color: fade(#b56277, 80%);
-    border:none;
-  }
-
+.minimap-highlights() when (lightness(@syntax-background-color) > 50%) {
   // Light theme
   .es-identifier-highlight.light-theme {
     background-color: fade(#000, 80%);
@@ -68,4 +57,26 @@
     background-color: fade(#baa8ff, 80%);
     border:none;
   }
+}
+
+.minimap-highlights() when (lightness(@syntax-background-color) <= 50%) {
+  // Default theme
+  .es-identifier-highlight {
+    background-color: @text-color-highlight;
+    border:1px solid #ddd;
+  }
+
+  .es-identifier-highlight.line {
+    background-color: fade(#036b13, 80%);
+    border:none;
+  }
+
+  .es-identifier-highlight.line.definition {
+    background-color: fade(#b56277, 80%);
+    border:none;
+  }
+}
+
+.minimap {
+  .minimap-highlights();
 }


### PR DESCRIPTION
An override still could be provided, but would really only be needed for badly coded themes.
