### PR TITLE
Allow reserved words during module parse

### DIFF
--- a/lib/inspector/inspector.js
+++ b/lib/inspector/inspector.js
@@ -52,6 +52,7 @@ export default class Inspector {
     _createAST(code) {
         try {
             this._ast = acorn.parse(code, {
+                allowReserved: true,
                 ranges: true,
                 ecmaVersion: 6,
                 sourceType: 'module',


### PR DESCRIPTION
Some modules (https://github.com/yortus/asyncawait) may use reserved words which cause acorn throwing an exception and highlighting stops working in those files. Passing 'allowReserved' option fix this behavior. 
Sorry for my bad english :(
